### PR TITLE
Fixed headings ending with #

### DIFF
--- a/docs/csharp-ide/using-the-visual-studio-development-environment-for-csharp.md
+++ b/docs/csharp-ide/using-the-visual-studio-development-environment-for-csharp.md
@@ -37,7 +37,7 @@ translation.priority.mt:
   - "pt-br"
   - "tr-tr"
 ---
-# Using the Visual Studio Development Environment for C#
+# Using the Visual Studio Development Environment for C# #
 The Visual Studio integrated development environment (IDE) is a collection of development tools exposed through a common user interface. Some of the tools are shared with other [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] languages, and some, such as the C# compiler, are unique to Visual C#. This topic provides links to the most important Visual C# tools.  
   
 ## Related Topics  

--- a/docs/debugger/debugging-f-hash.md
+++ b/docs/debugger/debugging-f-hash.md
@@ -36,7 +36,7 @@ translation.priority.ht:
   - "zh-cn"
   - "zh-tw"
 ---
-# Debugging F#
+# Debugging F# #
 Debugging F# is similar to debugging any managed language, with a few exceptions:  
   
 -   The **Autos** window does not display F# variables.  

--- a/docs/debugger/edit-and-continue-not-supported-for-f-hash.md
+++ b/docs/debugger/edit-and-continue-not-supported-for-f-hash.md
@@ -36,5 +36,5 @@ translation.priority.ht:
   - "zh-cn"
   - "zh-tw"
 ---
-# Edit and Continue Not Supported for F#
+# Edit and Continue Not Supported for F# #
 Edit and Continue is not supported when you debug F# code. Edits to F# code are possible during a debugging session but should be avoided. Code changes are not applied during the debugging session. Therefore, any edits made to F# code while you debug will result in source code that does not match the code being debugged.

--- a/docs/debugger/format-specifiers-in-csharp.md
+++ b/docs/debugger/format-specifiers-in-csharp.md
@@ -47,7 +47,7 @@ translation.priority.mt:
   - "pt-br"
   - "tr-tr"
 ---
-# Format Specifiers in C#
+# Format Specifiers in C# #
 You can change the format in which a value is displayed in the **Watch** window using format specifiers. You can also use format specifiers in the **Immediate** window, the **Command** window, and even in source windows. If you pause on an expression in those windows, the result will appear in a DataTip. DataTips will reflect the format specifier in the DataTip display.  
   
  To use a format specifier, type the expression followed by a comma. After the comma, add the appropriate specifier.  

--- a/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
+++ b/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
@@ -36,7 +36,7 @@ translation.priority.ht:
   - "zh-cn"
   - "zh-tw"
 ---
-# Walkthrough: Writing a Visualizer in C#
+# Walkthrough: Writing a Visualizer in C# #
 This walkthrough shows how to write a simple visualizer by using C#. The visualizer you will create in this walkthrough displays the contents of a string using a Windows forms message box. This simple string visualizer is not especially useful in itself, but it shows the basic steps that you must follow to create more useful visualizers for other data types.  
   
 > [!NOTE]

--- a/docs/deployment/walkthrough-downloading-satellite-assemblies-on-demand-with-the-clickonce-deployment-api-using-the-designer.md
+++ b/docs/deployment/walkthrough-downloading-satellite-assemblies-on-demand-with-the-clickonce-deployment-api-using-the-designer.md
@@ -66,7 +66,7 @@ Windows Forms applications can be configured for multiple cultures through the u
   
 6.  Close the **Application Files** dialog box.  
   
-### To download satellite assemblies on demand in C#  
+### To download satellite assemblies on demand in C# #
   
 1.  Open the Program.cs file. If you do not see this file in Solution Explorer, select your project, and on the **Project** menu, click **Show All Files**.  
   

--- a/docs/ide/how-to-suppress-compiler-warnings.md
+++ b/docs/ide/how-to-suppress-compiler-warnings.md
@@ -32,7 +32,7 @@ translation.priority.mt:
 # How to: Suppress Compiler Warnings
 You can declutter a build log by specifying one or more kinds of compiler warnings that you don’t want it to contain. For example, you might use this technique to review some but not all of the information that’s generated automatically when you set the build-log verbosity to Normal, Detailed, or Diagnostic. For more information about verbosity, see [How to: View, Save, and Configure Build Log Files](../ide/how-to-view-save-and-configure-build-log-files.md).  
   
-### To suppress specific warnings for Visual C# or F#  
+### To suppress specific warnings for Visual C# or F# #
   
 1.  In **Solution Explorer**, choose the project in which you want to suppress warnings.  
   

--- a/docs/ide/managing-application-settings-dotnet.md
+++ b/docs/ide/managing-application-settings-dotnet.md
@@ -89,7 +89,7 @@ Application settings enable you to store application information dynamically. Se
   
  We strongly recommend that you use the `My.Settings` object and the default .settings file to access settings. This is because you can use the Settings Designer to assign properties to settings, and, additionally, user settings are automatically saved before application shutdown. However, your [!INCLUDE[vbprvb](../code-quality/includes/vbprvb_md.md)] application can access settings directly. In that case you have to access the `MySettings` class and use a custom .settings file in the root of the project. You must also save the user settings before ending the application, as you would do for a C# application; this is described in the following section.  
   
-## Accessing or Changing Application Settings at Run Time in Visual C#  
+## Accessing or Changing Application Settings at Run Time in Visual C# #
  In languages other than [!INCLUDE[vbprvb](../code-quality/includes/vbprvb_md.md)], such as [!INCLUDE[csprcs](../data-tools/includes/csprcs_md.md)], you must access the `Settings` class directly, as shown in the following [!INCLUDE[csprcs](../data-tools/includes/csprcs_md.md)] example.  
   
 ```c#  

--- a/docs/ide/walkthrough-building-an-application.md
+++ b/docs/ide/walkthrough-building-an-application.md
@@ -238,7 +238,7 @@ By completing this walkthrough, you’ll  become more familiar with several opti
   
      ![Build Solution command on the Build menu](../ide/media/exploreide-buildsolution.png "ExploreIDE-BuildSolution")  
   
-#### To specify a release build for Visual C#  
+#### To specify a release build for Visual C# #
   
 1.  Open the **Project Designer**.  
   

--- a/docs/profiling/how-to-use-the-concurrency-visualizer-markers-sdk.md
+++ b/docs/profiling/how-to-use-the-concurrency-visualizer-markers-sdk.md
@@ -92,7 +92,7 @@ This topic shows how to use the Concurrency Visualizer SDK to create spans and w
   
      ![Concurrency Visualizer with 3 custom marker series](../profiling/media/cvmarkerseriesnative.png "CvMarkerSeriesNative")  
   
-### To Use Visual Basic or C#  
+### To Use Visual Basic or C# #
   
 1.  Add Concurrency Visualizer SDK support to your application. For more information, see [Concurrency Visualizer SDK](../profiling/concurrency-visualizer-sdk.md).  
   


### PR DESCRIPTION
Without the second `#`, the trailing `#` is not shown. For example, [the article *Debugging F#*](https://docs.microsoft.com/en-us/visualstudio/debugger/debugging-f-hash), currently shows with the heading "Debugging F".