### PR TITLE
Add copyright metadata to Dotfuscator pages

### DIFF
--- a/docs/ide/dotfuscator/capabilities.md
+++ b/docs/ide/dotfuscator/capabilities.md
@@ -32,6 +32,7 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
+copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Capabilities of Dotfuscator

--- a/docs/ide/dotfuscator/capabilities.md
+++ b/docs/ide/dotfuscator/capabilities.md
@@ -32,7 +32,6 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
-copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Capabilities of Dotfuscator
@@ -81,6 +80,8 @@ When run, the processed application will transmit analytics data to a configured
 ## See Also
 
 [This topic in the full Dotfuscator CE User Guide][full]
+
+<!-- Copyright © 2017 PreEmptive Solutions, LLC -->
 
 [assemblies]: https://docs.microsoft.com/en-us/dotnet/articles/standard/assembly-format
 [uwp]: https://www.preemptive.com/blog/article/856-uwp-applications-in-dotfuscator-ce/91-dotfuscator-ce

--- a/docs/ide/dotfuscator/index.md
+++ b/docs/ide/dotfuscator/index.md
@@ -32,7 +32,6 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
-copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Dotfuscator Community Edition (CE)
@@ -91,6 +90,8 @@ You can also get the **latest version** of Dotfuscator CE from [the Dotfuscator 
 This page and its sub-pages provide a high-level overview of Dotfuscator CE's features, as well as [instructions for installing the tool][install].
 
 Please see [the full Dotfuscator CE User Guide at preemptive.com][full] for detailed usage instructions, including [how to start using the Dotfuscator CE user interface][get-started].
+
+<!-- Copyright © 2017 PreEmptive Solutions, LLC -->
 
 [assemblies]: https://docs.microsoft.com/en-us/dotnet/articles/standard/assembly-format
 [software-protection]: https://www.preemptive.com/software-protection

--- a/docs/ide/dotfuscator/index.md
+++ b/docs/ide/dotfuscator/index.md
@@ -32,6 +32,7 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
+copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Dotfuscator Community Edition (CE)

--- a/docs/ide/dotfuscator/install.md
+++ b/docs/ide/dotfuscator/install.md
@@ -37,7 +37,6 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
-copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Install Dotfuscator Community Edition (CE)
@@ -86,6 +85,8 @@ Once the installation is complete, you can start using Dotfuscator CE. For detai
 ## See Also
 
 [This topic in the full Dotfuscator CE User Guide][full]
+
+<!-- Copyright © 2017 PreEmptive Solutions, LLC -->
 
 [2017-install]: https://www.visualstudio.com/downloads/#vs-2017
 [get-started]: https://www.preemptive.com/dotfuscator/ce/docs/help/5.27/gui_getstarted.html

--- a/docs/ide/dotfuscator/install.md
+++ b/docs/ide/dotfuscator/install.md
@@ -37,6 +37,7 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
+copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Install Dotfuscator Community Edition (CE)

--- a/docs/ide/dotfuscator/upgrades.md
+++ b/docs/ide/dotfuscator/upgrades.md
@@ -39,6 +39,7 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
+copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Upgrade Dotfuscator Community Edition (CE)

--- a/docs/ide/dotfuscator/upgrades.md
+++ b/docs/ide/dotfuscator/upgrades.md
@@ -39,7 +39,6 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
-copyright: "Copyright © 2017 PreEmptive Solutions, LLC"
 ---
 
 # Upgrade Dotfuscator Community Edition (CE)
@@ -91,6 +90,8 @@ For more information on the advanced application protection features of Dotfusca
 ## See Also
 
 [This topic in the full Dotfuscator CE User Guide][full]
+
+<!-- Copyright © 2017 PreEmptive Solutions, LLC -->
 
 [control-flow]: https://www.preemptive.com/products/dotfuscator/features#controlflow
 [string-encryption]: https://www.preemptive.com/products/dotfuscator/features#string


### PR DESCRIPTION
Since the Dotfuscator CE pages are managed by PreEmptive Solutions, this PR adds copyright lines to the metadata.