### PR TITLE
Add and fix up existing references to Dotfuscator

### DIFF
--- a/docs/csharp-ide/using-the-visual-studio-development-environment-for-csharp.md
+++ b/docs/csharp-ide/using-the-visual-studio-development-environment-for-csharp.md
@@ -1,7 +1,7 @@
 ---
 title: "Using the Visual Studio Development Environment for C# | Microsoft Docs"
 ms.custom: ""
-ms.date: "11/04/2016"
+ms.date: "02/17/2017"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
@@ -59,6 +59,7 @@ The Visual Studio integrated development environment (IDE) is a collection of de
 |[Compiling and Building](../ide/compiling-and-building-in-visual-studio.md)|Explains how to configure debug, release, and special builds of your Visual Studio solution.|  
 |[Debugging in Visual Studio](../debugger/debugging-in-visual-studio.md)|Describes how to run the Visual Studio Debugger to resolve logic and semantic errors.|  
 |[Managing Application Resources (.NET)](../ide/managing-application-resources-dotnet.md)|Shows how to add or edit resources for your project, such as strings, images, icons, audio, and files.|  
+|[Dotfuscator Community Edition (CE)](../ide/dotfuscator/index.md)|Explains how to set up and start using the free version of Dotfuscator to protect .NET assemblies from reverse-engineering and unauthorized use (such as unauthorized debugging).|  
   
 ## See Also  
  [C#](/dotnet/csharp/csharp)   

--- a/docs/csharp-ide/using-the-visual-studio-development-environment-for-csharp.md
+++ b/docs/csharp-ide/using-the-visual-studio-development-environment-for-csharp.md
@@ -59,7 +59,7 @@ The Visual Studio integrated development environment (IDE) is a collection of de
 |[Compiling and Building](../ide/compiling-and-building-in-visual-studio.md)|Explains how to configure debug, release, and special builds of your Visual Studio solution.|  
 |[Debugging in Visual Studio](../debugger/debugging-in-visual-studio.md)|Describes how to run the Visual Studio Debugger to resolve logic and semantic errors.|  
 |[Managing Application Resources (.NET)](../ide/managing-application-resources-dotnet.md)|Shows how to add or edit resources for your project, such as strings, images, icons, audio, and files.|  
-|[Dotfuscator Community Edition (CE)](../ide/dotfuscator/index.md)|Explains how to set up and start using the free version of Dotfuscator to protect .NET assemblies from reverse-engineering and unauthorized use (such as unauthorized debugging).|  
+|[Dotfuscator Community Edition (CE)](../ide/dotfuscator/index.md)|Explains how to set up and start using the free PreEmptive Protection - Dotfuscator Community Edition to protect .NET assemblies from reverse-engineering and unauthorized use (such as unauthorized debugging).|  
   
 ## See Also  
  [C#](/dotnet/csharp/csharp)   

--- a/docs/deployment/securing-clickonce-applications.md
+++ b/docs/deployment/securing-clickonce-applications.md
@@ -88,7 +88,7 @@ translation.priority.mt:
 >  Query-string arguments are the only way to pass arguments to a [!INCLUDE[ndptecclick](../deployment/includes/ndptecclick_md.md)] application at startup. You cannot pass arguments to a [!INCLUDE[ndptecclick](../deployment/includes/ndptecclick_md.md)] application from the command line.  
   
 ## Deploying Obfuscated Assemblies  
- Visual Studio includes the free [Dotfuscator Community Edition](../ide/dotfuscator/index.md), which you can use to protect your ClickOnce applications through code obfuscation and active protection measures.  For details, please see [the ClickOnce section of the Dotfuscator Community Edition User Guide](https://www.preemptive.com/dotfuscator/ce/docs/help/5.27/advanced_clickonce.html).
+ Visual Studio includes the free [PreEmptive Protection - Dotfuscator Community Edition](../ide/dotfuscator/index.md), which you can use to protect your ClickOnce applications through code obfuscation and active protection measures.  For details, please see [the ClickOnce section of the Dotfuscator Community Edition User Guide](https://www.preemptive.com/dotfuscator/ce/docs/help/5.27/advanced_clickonce.html).
 
 ## See Also  
  [ClickOnce Security and Deployment](../deployment/clickonce-security-and-deployment.md)   

--- a/docs/deployment/securing-clickonce-applications.md
+++ b/docs/deployment/securing-clickonce-applications.md
@@ -1,7 +1,7 @@
 ---
 title: "Securing ClickOnce Applications | Microsoft Docs"
 ms.custom: ""
-ms.date: "11/04/2016"
+ms.date: "02/17/2017"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
@@ -88,14 +88,8 @@ translation.priority.mt:
 >  Query-string arguments are the only way to pass arguments to a [!INCLUDE[ndptecclick](../deployment/includes/ndptecclick_md.md)] application at startup. You cannot pass arguments to a [!INCLUDE[ndptecclick](../deployment/includes/ndptecclick_md.md)] application from the command line.  
   
 ## Deploying Obfuscated Assemblies  
- You might want to obfuscate your application by using Dotfuscator to prevent others from reverse engineering the code. However, assembly obfuscation is not integrated into the Visual Studio IDE or the ClickOnce deployment process. Therefore, you will have to perform the obfuscation outside of the deployment process, perhaps using a post-build step. After you build the project, you would perform the following steps manually, outside of Visual Studio:  
-  
-1.  Perform the obfuscation by using Dotfuscator.  
-  
-2.  Use Mage.exe or MageUI.exe to generate the ClickOnce manifests and sign them. For more information, see [Mage.exe (Manifest Generation and Editing Tool)](http://msdn.microsoft.com/Library/77dfe576-2962-407e-af13-82255df725a1) and [MageUI.exe (Manifest Generation and Editing Tool, Graphical Client)](http://msdn.microsoft.com/Library/f9e130a6-8117-49c4-839c-c988f641dc14).  
-  
-3.  Manually publish (copy) the files to your deployment source location (Web server, UNC share, or CD-ROM).  
-  
+ Visual Studio includes the free [Dotfuscator Community Edition](../ide/dotfuscator/index.md), which you can use to protect your ClickOnce applications through code obfuscation and active protection measures.  For details, please see [the ClickOnce section of the Dotfuscator Community Edition User Guide](https://www.preemptive.com/dotfuscator/ce/docs/help/5.27/advanced_clickonce.html).
+
 ## See Also  
  [ClickOnce Security and Deployment](../deployment/clickonce-security-and-deployment.md)   
  [Choosing a ClickOnce Deployment Strategy](../deployment/choosing-a-clickonce-deployment-strategy.md)

--- a/docs/extensibility/visual-studio-shell-integrated.md
+++ b/docs/extensibility/visual-studio-shell-integrated.md
@@ -1,7 +1,7 @@
 ---
 title: "Visual Studio Shell (Integrated) | Microsoft Docs"
 ms.custom: ""
-ms.date: "11/04/2016"
+ms.date: "02/17/2017"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
@@ -80,7 +80,7 @@ The Visual Studio integrated shell includes the integrated development environme
   
 -   Class Designer  
   
--   Pre-Emptive DotFuscator  
+-   [PreEmptive Protection - Dotfuscator](../ide/dotfuscator/index.md)  
   
 -   Language features  
   

--- a/docs/ide/managing-assembly-and-manifest-signing.md
+++ b/docs/ide/managing-assembly-and-manifest-signing.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing Assembly and Manifest Signing | Microsoft Docs"
 ms.custom: ""
-ms.date: "11/04/2016"
+ms.date: "02/17/2017"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
@@ -41,6 +41,9 @@ Strong-name signing gives a software component a globally unique identity. Stron
  For information about signing assemblies in Visual Basic and C# projects, see [Creating and Using Strong-Named Assemblies](http://msdn.microsoft.com/Library/ffbf6d9e-4a88-4a8a-9645-4ce0ee1ee5f9).  
   
  For information about signing assemblies in Visual C++ projects, see [Strong Name Assemblies (Assembly Signing) (C++/CLI)](/visual-cpp/dotnet/strong-name-assemblies-assembly-signing-cpp-cli).  
+
+> [!NOTE]
+>  Strong-name signing does not protect against reverse-engineering of the assembly.  To protect against reverse-engineering, see [Dotfuscator Community Edition (CE)](dotfuscator/index.md).
   
 ## Asset Types and Signing  
  You can sign .NET assemblies and application manifests. These include the following:  

--- a/docs/ide/managing-external-tools.md
+++ b/docs/ide/managing-external-tools.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage external tools | Microsoft Docs"
 ms.custom: ""
-ms.date: "01/23/2017"
+ms.date: "02/17/2017"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
@@ -77,26 +77,17 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # Manage external tools
-You can call external tools from inside Visual Studio. A few default tools are available from the **Tools** menu, but you can add other executables of your own.  
-  
+You can call external tools from inside Visual Studio by using the **Tools** menu. A few default tools are available from the **Tools** menu, but you can add other executables of your own.  
+
 ## Tools available on the Visual Studio Tools menu
- You can call the following tools from the **Tools** menu in [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)]. You can also call them by name from the **Quick Launch** window. For example, to call GuidGen.exe, type **Create GUID**.  
-  
-1.  Create GUID: generates a GUID.  
-  
-2.  Error Lookup: gets an error message from the value entered. For more information, see [ERRLOOK Reference](/visual-cpp/build/reference/errlook-reference).  
-  
-3.  ATL/MFC Trace Tool: shows debug trace messages in the ATL and MFC sources.  
-  
-4.  PreEmptive Dotfuscator and Analytics: Protects .NET programs against reverse engineering.  
-  
-5.  SPY++: Displays processes, threads, windows, and window messages graphically.  
-  
-6.  WCF Service Configuration Editor: Allows you to create and modify configuration settings for WCF services.  
-  
-> [!WARNING]
->  You may see a different list of external tools, depending on which Visual Studio edition you have installed and the settings profile you have applied. For more information, see [Customizing Development Settings in Visual Studio](http://msdn.microsoft.com/en-us/22c4debb-4e31-47a8-8f19-16f328d7dcd3).  
-  
+ The **Tools** menu contains several built-in commands, such as:
+
+*  **Extensions and Updates** for [managing Visual Studio Extensions](finding-and-using-visual-studio-extensions.md)
+*  **Code Snippets Manager...** for [organizing Code Snippets](code-snippets.md#code-snippet-manager)
+*  **PreEmptive Protection - Dotfuscator** for launching [Dotfuscator Community Edition (CE)](dotfuscator/index.md) if it is [installed](dotfuscator/install.md)
+*  **Customize...** for [customizing menus and toolbars](how-to-customize-menus-and-toolbars-in-visual-studio)
+*  **Options...** for [setting a variety of different options for the Visual Studio IDE and other tools](reference/options-dialog-box-visual-studio.md)
+
 ## Add new tools to the Tools menu 
  You can add an external tool to the **Tools** menu. Open the **External Tools** dialog box and click **Add**, then fill in the information. For example, the following entry causes Windows Explorer to open at the directory of the file you currently have open in Visual Studio:  
   
@@ -106,8 +97,7 @@ You can call external tools from inside Visual Studio. A few default tools are a
   
 3.  Arguments: /root, "$(ItemDir)"  
   
-## Arguments for external tools  
- The following arguments are Visual Studio variables that are assigned when you launch an external tool. Links to external tools such as Notepad or Spy++ can be listed on the **Tools** menu using the External Tools dialog box.  
+ The following is a full list of arguments that can be used when defining an external tool.
   
 > [!NOTE]
 >  The IDE status bar displays the Current Line and Current Column variables to indicate where the insertion point is located in the active Code Editor. The Current Text variable returns the text or code selected at that location.  
@@ -130,6 +120,6 @@ You can call external tools from inside Visual Studio. A few default tools are a
 |Project file name|$(ProjFileName)|The file name of the current project (drive + path + file name).|  
 |Solution Directory|$(SolutionDir)|The directory of the current solution (drive + path).|  
 |Solution file name|$(SolutionFileName)|The file name of the current solution (drive + path + file name).|  
-  
+
 ## See also  
  [C/C++ Build Tools](/visual-cpp/build/reference/c-cpp-build-tools)

--- a/docs/ide/managing-external-tools.md
+++ b/docs/ide/managing-external-tools.md
@@ -89,13 +89,13 @@ You can call external tools from inside Visual Studio by using the **Tools** men
 *  **Options...** for [setting a variety of different options for the Visual Studio IDE and other tools](reference/options-dialog-box-visual-studio.md)
 
 ## Add new tools to the Tools menu 
- You can add an external tool to the **Tools** menu. Open the **External Tools** dialog box and click **Add**, then fill in the information. For example, the following entry causes Windows Explorer to open at the directory of the file you currently have open in Visual Studio:  
+ You can add an external tool to the **Tools** menu. Open the **External Tools...** dialog box and click **Add**, then fill in the information. For example, the following entry causes Windows Explorer to open at the directory of the file you currently have open in Visual Studio:  
   
-1.  Title: Open File Location  
+1.  Title: *Open File Location*
   
-2.  Command: explorer.exe  
+2.  Command: `explorer.exe`  
   
-3.  Arguments: /root, "$(ItemDir)"  
+3.  Arguments: `/root, "$(ItemDir)"`  
   
  The following is a full list of arguments that can be used when defining an external tool.
   

--- a/docs/ide/security-in-visual-studio.md
+++ b/docs/ide/security-in-visual-studio.md
@@ -56,7 +56,7 @@ You should consider security in all aspects of your application development, fro
  Security is also an important consideration in the build process.  A few additional steps can improve the security of a deployed app, and help prevent unauthorized reverse engineering, spoofing, or other attacks.
 
  [Dotfuscator Community Edition (CE)](dotfuscator/index.md)  
- Explains how to set up and start using the free version of Dotfuscator to protect .NET assemblies from reverse-engineering and unauthorized use (such as unauthorized debugging).
+ Explains how to set up and start using the free PreEmptive Protection - Dotfuscator Community Edition to protect .NET assemblies from reverse-engineering and unauthorized use (such as unauthorized debugging).
   
  [Managing Assembly and Manifest Signing](managing-assembly-and-manifest-signing.md)  
  Discusses strong-name signing, which can be used to uniquely identify software components, preventing name spoofing.

--- a/docs/ide/security-in-visual-studio.md
+++ b/docs/ide/security-in-visual-studio.md
@@ -1,7 +1,7 @@
 ---
 title: "Security in Visual Studio | Microsoft Docs"
 ms.custom: ""
-ms.date: "11/04/2016"
+ms.date: "02/17/2017"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
@@ -51,3 +51,12 @@ You should consider security in all aspects of your application development, fro
   
  [Security Best Practices](/visual-cpp/top/security-best-practices-for-cpp)  
  Discusses buffer overruns and the complete picture of the Microsoft Visual C++ security checks feature provided by the /GS compile-time flag.
+
+## Building for Security  
+ Security is also an important consideration in the build process.  A few additional steps can improve the security of a deployed app, and help prevent unauthorized reverse engineering, spoofing, or other attacks.
+
+ [Dotfuscator Community Edition (CE)](dotfuscator/index.md)  
+ Explains how to set up and start using the free version of Dotfuscator to protect .NET assemblies from reverse-engineering and unauthorized use (such as unauthorized debugging).
+  
+ [Managing Assembly and Manifest Signing](managing-assembly-and-manifest-signing.md)  
+ Discusses strong-name signing, which can be used to uniquely identify software components, preventing name spoofing.

--- a/docs/test/improve-code-quality.md
+++ b/docs/test/improve-code-quality.md
@@ -57,7 +57,7 @@ What is code quality? Correctness, maintainability, and even elegance are all in
  You can use [!INCLUDE[vsPreShort](../test/includes/vspreshort_md.md)] and [!INCLUDE[vsUltShort](../test/includes/vsultshort_md.md)] to be more productive throughout the testing life cycle. [!INCLUDE[vsPreShort](../test/includes/vspreshort_md.md)] or [!INCLUDE[vsUltShort](../test/includes/vsultshort_md.md)] let you plan your testing effort. You can create, manage, edit, and run both manual and automated tests. You can also review your testing progress based on your plan.  
   
  [Protecting the application with PreEmptive Protection - Dotfuscator](../ide/dotfuscator/index.md)  
- You can use Dotfuscator Community Edition (CE) to help secure trade secrets and other intellectual property (IP), reduce piracy and counterfeiting, and protect against tampering and unauthorized debugging.  Dotfuscator protects and hardens compiled assemblies without the need for additional programming or even access to source code.
+ You can use the free Dotfuscator Community Edition to help secure trade secrets and other intellectual property (IP), reduce piracy and counterfeiting, and protect against tampering and unauthorized debugging.  Dotfuscator protects and hardens compiled assemblies without the need for additional programming or even access to source code.
   
  [Building the application](https://www.visualstudio.com/docs/build/overview)  
  You can use [!INCLUDE[esprbuild](../test/includes/esprbuild_md.md)] to create and manage automated builds for your code. [!INCLUDE[esprbuild](../test/includes/esprbuild_md.md)] lets you create drop servers to deploy builds. In addition, you can analyze build trends.  

--- a/docs/test/improve-code-quality.md
+++ b/docs/test/improve-code-quality.md
@@ -1,7 +1,7 @@
 ---
 title: "Improve Code Quality"
 ms.custom: na
-ms.date: "10/14/2016"
+ms.date: "02/17/2017"
 ms.reviewer: na
 ms.suite: na
 ms.technology: 
@@ -45,7 +45,6 @@ What is code quality? Correctness, maintainability, and even elegance are all in
 |[Unit Test Your Code](../test/unit-test-your-code.md)|Test Explorer makes it easy to integrate unit tests in your development practice. You can use the Microsoft unit test framework or one of several third-party and open source frameworks.|  
 |[Analyzing Application Quality](../code-quality/analyzing-application-quality-by-using-code-analysis-tools.md)|Static code analysis tools find design, usage, maintainablity, and style issues in C++ and managed code. Many of these issues can lead to bugs that are hard to reproduce in standard testing environment.|  
 |[Measuring Complexity and Maintainability of Managed Code](../code-quality/measuring-complexity-and-maintainability-of-managed-code.md)|Code metrics is a set of software measures that provide developers better insight into the code they are developing. The metrics include a maintainability index for functions and classes, cyclomatic complexity of functions, the inheritance depth of classes, and the amount of coupling among classes.|  
-|[PreEmptive Analytics for Team Foundation Server](http://msdn.microsoft.com/library/hh973124.aspx)|PreEmptive Analytics for TFS CE helps you to integrate feedback-driven development processes into your development workflow. Your applications automatically send back exception report data to the PreEmptive Analytics service as errors occur during their execution. The service then creates or updates work items in Microsoft Team Foundation Server based on rules and thresholds you define.|  
 |[PreEmptive Dotfuscator and Analytics CE](assetId:///25d195d4-9f76-4dcc-9fbb-eeb9bdca9a3f)|PreEmptive Dotfuscator is a.NET obfuscator and compactor that helps protect programs against reverse engineering while making them smaller and more efficient.|  
   
 ## Related Scenarios  

--- a/docs/test/improve-code-quality.md
+++ b/docs/test/improve-code-quality.md
@@ -45,7 +45,6 @@ What is code quality? Correctness, maintainability, and even elegance are all in
 |[Unit Test Your Code](../test/unit-test-your-code.md)|Test Explorer makes it easy to integrate unit tests in your development practice. You can use the Microsoft unit test framework or one of several third-party and open source frameworks.|  
 |[Analyzing Application Quality](../code-quality/analyzing-application-quality-by-using-code-analysis-tools.md)|Static code analysis tools find design, usage, maintainablity, and style issues in C++ and managed code. Many of these issues can lead to bugs that are hard to reproduce in standard testing environment.|  
 |[Measuring Complexity and Maintainability of Managed Code](../code-quality/measuring-complexity-and-maintainability-of-managed-code.md)|Code metrics is a set of software measures that provide developers better insight into the code they are developing. The metrics include a maintainability index for functions and classes, cyclomatic complexity of functions, the inheritance depth of classes, and the amount of coupling among classes.|  
-|[PreEmptive Dotfuscator and Analytics CE](assetId:///25d195d4-9f76-4dcc-9fbb-eeb9bdca9a3f)|PreEmptive Dotfuscator is a.NET obfuscator and compactor that helps protect programs against reverse engineering while making them smaller and more efficient.|  
   
 ## Related Scenarios  
  [Adopting Visual Studio and Team Foundation Server for Application Lifecycle Management](assetId:///7ae9182f-4762-4bd3-b238-39ce987932e5)  
@@ -57,8 +56,11 @@ What is code quality? Correctness, maintainability, and even elegance are all in
  [Testing the application](https://www.visualstudio.com/docs/test/overview)  
  You can use [!INCLUDE[vsPreShort](../test/includes/vspreshort_md.md)] and [!INCLUDE[vsUltShort](../test/includes/vsultshort_md.md)] to be more productive throughout the testing life cycle. [!INCLUDE[vsPreShort](../test/includes/vspreshort_md.md)] or [!INCLUDE[vsUltShort](../test/includes/vsultshort_md.md)] let you plan your testing effort. You can create, manage, edit, and run both manual and automated tests. You can also review your testing progress based on your plan.  
   
- [Build the application](https://www.visualstudio.com/docs/build/overview)  
+ [Protecting the application with PreEmptive Protection - Dotfuscator](../ide/dotfuscator/index.md)  
+ You can use Dotfuscator Community Edition (CE) to help secure trade secrets and other intellectual property (IP), reduce piracy and counterfeiting, and protect against tampering and unauthorized debugging.  Dotfuscator protects and hardens compiled assemblies without the need for additional programming or even access to source code.
+  
+ [Building the application](https://www.visualstudio.com/docs/build/overview)  
  You can use [!INCLUDE[esprbuild](../test/includes/esprbuild_md.md)] to create and manage automated builds for your code. [!INCLUDE[esprbuild](../test/includes/esprbuild_md.md)] lets you create drop servers to deploy builds. In addition, you can analyze build trends.  
   
- [Track work using Visual Studio Online or Team Foundation Server](https://www.visualstudio.com/docs/work/overview)  
+ [Tracking work using Visual Studio Online or Team Foundation Server](https://www.visualstudio.com/docs/work/overview)  
  You can use [!INCLUDE[vstsTfsLong](../test/includes/vststfslong_md.md)] to plan and track your projects whether you use the agile process, the formal process, or a variation on those processes. By planning your projects, tracking your progress against the plan, and making necessary adjustments, you can reduce risks, avoid unpleasant surprises, and manage the cost of your projects.


### PR DESCRIPTION
Several pages already make reference to Dotfuscator (the code protection tool included in Visual Studio), but are out-of-date. This pull request updates those references, and adds a few more to relevant sections. 

Some affected pages have been further edited to more accurately reflect Visual Studio 2017. In particular, [the Managing External Tools page](https://github.com/preemptive/visualstudio-docs/blob/c36d97b83aa0892235c8f196cf6af63520b3547c/docs/ide/managing-external-tools.md) has been modified to reflect 2017's smaller default Tools menu.

An outstanding question is whether the `helpviewer_keywords` metadata on that page should be updated - I didn't want to remove anything without running through the official channels first.

*Note*: This PR is made at the request of my employer, @preemptive, which owns Dotfuscator.