### PR TITLE
Correct return value of MSBuild FindInList task

### DIFF
--- a/docs/msbuild/findinlist-task.md
+++ b/docs/msbuild/findinlist-task.md
@@ -46,7 +46,7 @@ In a specified list, finds an item that has the matching itemspec.
 |---------------|-----------------|  
 |`CaseSensitive`|Optional `Boolean` parameter.<br /><br /> If `true`, the search is case-sensitive; otherwise, it is not. Default value is `true`.|  
 |`FindLastMatch`|Optional `Boolean` parameter.<br /><br /> If `true`, return the last match; otherwise, return the first match. Default value is `false`.|  
-|`ItemFound`|Optional <xref:Microsoft.Build.Framework.ITaskItem>`[]` read-only output parameter.<br /><br /> The first matching item found in the list, if any.|  
+|`ItemFound`|Optional <xref:Microsoft.Build.Framework.ITaskItem> read-only output parameter.<br /><br /> The matching item found in the list, if any.|
 |`ItemSpecToFind`|Required `String` parameter.<br /><br /> The itemspec to search for.|  
 |`List`|Required <xref:Microsoft.Build.Framework.ITaskItem>`[]` parameter.<br /><br /> The list in which to search for the itemspec.|  
 |`MatchFileNameOnly`|Optional `Boolean` parameter.<br /><br /> If `true`, match against just the file name part of the itemspec; otherwise, match against the whole itemspec. Default value is `true`.|  


### PR DESCRIPTION
The [`ItemFound` output](https://github.com/Microsoft/msbuild/blob/c3767247a4bf5c9e5771caef3413ac318b0fd1a3/src/Tasks/FindInList.cs#L61) of `FindInList` is a single value, not a list.

Also corrected confusing language--it might be the first or the last value that matches in the list, depending on the value of the input `FindLastMatch`.