### PR TITLE
Fix component ID

### DIFF
--- a/docs/extensibility/how-to-migrate-extensibility-projects-to-visual-studio-2017.md
+++ b/docs/extensibility/how-to-migrate-extensibility-projects-to-visual-studio-2017.md
@@ -186,7 +186,7 @@ To provide further guidance, we have identified a few common extension types and
 
 Extension Type | Display Name |	Id
 --- | --- | ---
-Editor | Visual Studio core editor	| Microsoft.VisualStudio.CoreEditor
+Editor | Visual Studio core editor	| Microsoft.VisualStudio.Component.CoreEditor
 Roslyn | C# and Visual Basic | Microsoft.VisualStudio.Component.Roslyn.LanguageServices
 WPF | Managed Desktop Workload Core | Microsoft.VisualStudio.Component.ManagedDesktop.Core
 Debugger | Just-In-Time debugger | Microsoft.VisualStudio.Component.Debugger.JustInTime


### PR DESCRIPTION
This document uses two different component IDs for _Visual Studio core editor_.

From my testing, it seems that `Microsoft.VisualStudio.Component.CoreEditor` is the correct one, not `Microsoft.VisualStudio.CoreEditor`.