### PR TITLE
Update download links with direct link to product

### DIFF
--- a/docs/install/create-an-offline-installation-of-visual-studio.md
+++ b/docs/install/create-an-offline-installation-of-visual-studio.md
@@ -40,17 +40,17 @@ We understand that a lot of customers want an offline installer for [Visual Stud
 Here's how.
 
 ## Download the setup file you want
-**[Download](https://www.visualstudio.com/downloads?utm_source=mscom&utm_campaign=msdocs)** the edition of Visual Studio that you want. Make sure to click **Save**, and then click **Open folder**.
+**Download** the edition of Visual Studio you want. Make sure to click **Save**, and then click **Open folder**.
 
 Your setup file&mdash;or to be more specific, a bootstrapper file&mdash;will match one of the following.
 
-|Edition | File|  
-|-------------|-----------------------|  
-|Visual Studio Enterprise |**vs_enterprise.exe**|  
-|Visual Studio Professional |**vs_professional.exe**|  
-|Visual Studio Community |**vs_community.exe**|
+|Edition | File| Download|
+|-------------|-----------------------|-----|
+|Visual Studio Enterprise |**vs_enterprise.exe**| [https://aka.ms/vs/15/release/vs_enterprise.exe](https://aka.ms/vs/15/release/vs_enterprise.exe) |
+|Visual Studio Professional |**vs_professional.exe**| [https://aka.ms/vs/15/release/vs_professional.exe](https://aka.ms/vs/15/release/vs_professional.exe) |
+|Visual Studio Community |**vs_community.exe**| [https://aka.ms/vs/15/release/vs_community.exe](https://aka.ms/vs/15/release/vs_community.exe) |
 
-Other supported bootstrappers include vs_buildtools.exe, vs_feedbackclient.exe, vs_teamexplorer.exe, vs_testagent.exe, vs_testcontroller.exe, and vs_testprofessional.exe.
+Other supported bootstrappers include [vs_buildtools.exe](https://aka.ms/vs/15/release/vs_buildtools.exe), [vs_feedbackclient.exe](https://aka.ms/vs/15/release/vs_feedbackclient.exe), [vs_teamexplorer.exe](https://aka.ms/vs/15/release/vs_teamexplorer.exe), [vs_testagent.exe](https://aka.ms/vs/15/release/vs_testagent.exe), [vs_testcontroller.exe](https://aka.ms/vs/15/release/vs_testcontroller.exe), and [vs_testprofessional.exe](https://aka.ms/vs/15/release/vs_testprofessional.exe).
 
 ## Create an offline installation folder
 To create an offline installation with all languages and all features, use one of the commands from the following examples.

--- a/docs/install/create-an-offline-installation-of-visual-studio.md
+++ b/docs/install/create-an-offline-installation-of-visual-studio.md
@@ -44,11 +44,11 @@ Here's how.
 
 Your setup file&mdash;or to be more specific, a bootstrapper file&mdash;will match one of the following.
 
-|Edition | File| Download|
-|-------------|-----------------------|-----|
-|Visual Studio Enterprise |**vs_enterprise.exe**| [https://aka.ms/vs/15/release/vs_enterprise.exe](https://aka.ms/vs/15/release/vs_enterprise.exe) |
-|Visual Studio Professional |**vs_professional.exe**| [https://aka.ms/vs/15/release/vs_professional.exe](https://aka.ms/vs/15/release/vs_professional.exe) |
-|Visual Studio Community |**vs_community.exe**| [https://aka.ms/vs/15/release/vs_community.exe](https://aka.ms/vs/15/release/vs_community.exe) |
+|Edition | Download|
+|-------------|-----------------------|
+|Visual Studio Enterprise | [**vs_enterprise.exe**](https://aka.ms/vs/15/release/vs_enterprise.exe) |
+|Visual Studio Professional | [**vs_professional.exe**](https://aka.ms/vs/15/release/vs_professional.exe) |
+|Visual Studio Community | [**vs_community.exe**](https://aka.ms/vs/15/release/vs_community.exe) |
 
 Other supported bootstrappers include [vs_buildtools.exe](https://aka.ms/vs/15/release/vs_buildtools.exe), [vs_feedbackclient.exe](https://aka.ms/vs/15/release/vs_feedbackclient.exe), [vs_teamexplorer.exe](https://aka.ms/vs/15/release/vs_teamexplorer.exe), [vs_testagent.exe](https://aka.ms/vs/15/release/vs_testagent.exe), [vs_testcontroller.exe](https://aka.ms/vs/15/release/vs_testcontroller.exe), and [vs_testprofessional.exe](https://aka.ms/vs/15/release/vs_testprofessional.exe).
 


### PR DESCRIPTION
This fixes an ambiguity in the documentation where links from https://www.visualstudio.com/downloads?utm_source=mscom&utm_campaign=msdocs would produce an exe file with a number appended to the end. These links download the bootstrapper as they appear further down in the document