### PR TITLE
added a whitespace between a link and the word next to it

### DIFF
--- a/docs/code-quality/ca1704-identifiers-should-be-spelled-correctly.md
+++ b/docs/code-quality/ca1704-identifiers-should-be-spelled-correctly.md
@@ -68,7 +68,7 @@ translation.priority.mt:
   
 -   Add words that should cause a violation under the Dictionary/Words/Unrecognized path.  
   
--   Add words that should be flagged as obsolete under the Dictionary/Words/Deprecated path. See the related rule topic [CA1726: Use preferred terms](../code-quality/ca1726-use-preferred-terms.md)for more information.  
+-   Add words that should be flagged as obsolete under the Dictionary/Words/Deprecated path. See the related rule topic [CA1726: Use preferred terms](../code-quality/ca1726-use-preferred-terms.md) for more information.  
   
 -   Add exceptions to the acronym casing rules to the Dictionary/Acronyms/CasingExceptions path.  
   


### PR DESCRIPTION
A whitespace was missing between a link and the word next to it. See the screenshot:

![image](https://cloud.githubusercontent.com/assets/1393989/25465887/bbde30b2-2b37-11e7-9915-b91a9de66365.png)
