### PR TITLE
Update uint8clampedarray-object-javascript.md

### DIFF
--- a/scripting-docs/javascript/reference/uint8clampedarray-object-javascript.md
+++ b/scripting-docs/javascript/reference/uint8clampedarray-object-javascript.md
@@ -53,7 +53,7 @@ uint8ClampedArray = new Uint8ClampedArray( buffer, byteOffset, length);
 ## Remarks  
  Values stored in a `Uint8ClampedArray` object are between 0 and 255. If you set a negative value for an array member, 0 is set for the value. If you set a value that is larger than 255, 255 is set as the value.  
   
- Values in a `Uint8ClampedArray` object are rounded to the nearest event value, which is called banker's rounding.  
+ Values in a `Uint8ClampedArray` object are rounded to the nearest even value, which is called banker's rounding.  
   
 ## Constants  
  The following table lists the constants of the `Uint8ClampedArray` object.  
@@ -119,7 +119,7 @@ ints[1] = 256; // 255 will be assigned.
 ```  
 var ints = new Uint8ClampedArray(4);  
 ints[0] = 11.3; // 11 will be assigned (same as Int8Array).  
-ints[1] = 11.8; // 11 will be assigned (same as Int8Array).  
+ints[1] = 11.8; // 12 will be assigned (same as Int8Array).  
 ints[2] = 10.5; // 10 will be assigned (rounded to the nearest   
                 // even value).  
 ints[3] = 11.5; // 12 will be assigned (rounded to the nearest   


### PR DESCRIPTION
- Fix spelling error in the description of banker's rounding under the Remarks section
- Fix an example for the rounding of values