### PR TITLE
Fixed Typo

### DIFF
--- a/mac/uninstall.md
+++ b/mac/uninstall.md
@@ -35,7 +35,7 @@ rm -rf ~/Library/Caches/VisualStudio
 rm -rf ~/Library/Preferences/VisualStudio
 rm -rf "~/Library/Preferences/Visual Studio"
 rm -rf ~/Library/Logs/VisualStudio
-rm -rf ~/Library/VisualLodStudio
+rm -rf ~/Library/VisualStudio
 rm -rf ~/Library/Preferences/Xamarin/
 ```
 


### PR DESCRIPTION
Fixed typo for ~/Library/VisualStudio. It was written as ~/Library/VisualLodStudio