### PR TITLE
Updated Mono Uninstallation Command

### DIFF
--- a/mac/uninstall.md
+++ b/mac/uninstall.md
@@ -52,6 +52,7 @@ To remove the Mono Framework from a machine, run the following commands in Termi
 ```bash
 sudo rm -rf /Library/Frameworks/Mono.framework
 sudo pkgutil --forget com.xamarin.mono-MDK.pkg
+sudo rm -rf /etc/paths.d/mono-commands
 ```
 
 ## Uninstall Xamarin.Android


### PR DESCRIPTION
Added `sudo rm -rf /etc/paths.d/mono-commands` to Mono uninstallation command. This is based on official Mono website: http://www.mono-project.com/docs/about-mono/supported-platforms/osx/