### PR TITLE
Fix Directory.Build.targets name

### DIFF
--- a/docs/msbuild/msbuild-dot-targets-files.md
+++ b/docs/msbuild/msbuild-dot-targets-files.md
@@ -54,8 +54,8 @@ translation.priority.ht:
 |Microsoft.CSharp.targets|Defines the steps in the standard build process for Visual C# projects.<br /><br /> Imported by Visual C# project files (.csproj), which include the following statement: `<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />`|  
 |Microsoft.VisualBasic.targets|Defines the steps in the standard build process for Visual Basic projects.<br /><br /> Imported by Visual Basic project files (.vbproj), which include the following statement: `<Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />`|
 
-## Directory.Build.Props
-Directory.Build.Props is a user-defined file that provides customizations to projects under a directory. This file is automatically imported from Microsoft.Common.targets unless the property **ImportDirectoryBuildTargets** is set to **false**.
+## Directory.Build.targets
+Directory.Build.targets is a user-defined file that provides customizations to projects under a directory. This file is automatically imported from Microsoft.Common.targets unless the property **ImportDirectoryBuildTargets** is set to **false**.
 
 ## See Also  
  [Import Element (MSBuild)](../msbuild/import-element-msbuild.md)   


### PR DESCRIPTION
For this page, the file name should be `Directory.Build.targets` not `Directory.Build.props`