### PR TITLE
CMD or PS - still need quotes around spacey paths

### DIFF
--- a/docs/install/automatically-apply-product-keys-when-deploying-visual-studio.md
+++ b/docs/install/automatically-apply-product-keys-when-deploying-visual-studio.md
@@ -44,7 +44,7 @@ You can apply your product key programmatically as part of a script used to auto
  This is an example command line for applying the license for Visual Studio 2017 Enterprise, which has a MPC of 08860, with a product key `AAAAA-BBBBB-CCCCC-DDDDDD-EEEEEE`, assuming its installation into a default location:
 
  ```cmd
- C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\StorePID.exe AAAAA-BBBBB-CCCCC-DDDDDD-EEEEEE 08860
+ "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\StorePID.exe" AAAAA-BBBBB-CCCCC-DDDDDD-EEEEEE 08860
  ```
 
  The following table lists the MPC codes for each edition of Visual Studio:


### PR DESCRIPTION
paths with spaces and not surrounded by quotes result in errors. e.g. in PS:
PS C:\> C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\StorePID.exe 
x86 : The term 'x86' is not recognized ...

and CMD:
C:\>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\StorePID.exe
'C:\Program' is not recognized ...
